### PR TITLE
Fix discoverability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.2 - 2024-07-11
+### Fixed
+- Do not call `DeleteSyntheticNodes` on the call graph, because it prevents discoverability of calls to zconfig
+
 ## 0.1.1 - 2024-06-27
 ### Fixed
 - go module declaration

--- a/init_calls.go
+++ b/init_calls.go
@@ -85,7 +85,6 @@ func (c *checker) lookupInitCalls() {
 	}
 
 	graph := c.CallGraph()
-	graph.DeleteSyntheticNodes()
 	for _, node := range graph.Nodes {
 		if node.Func == nil {
 			continue


### PR DESCRIPTION
Calling `DeleteSyntheticNodes` on the call graph can lead to discoverability issues when looking up calls to zconfig.